### PR TITLE
docs : adds github template for issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,65 @@
+name: Bug report
+description: Report a reproducible problem in DSA Visualizer.
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug. Please provide clear steps so we can reproduce it quickly.
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues and didn't find a duplicate.
+          required: true
+        - label: I can reproduce this on the latest code from `main`.
+          required: false
+  - type: textarea
+    id: summary
+    attributes:
+      label: Bug summary
+      description: What happened?
+      placeholder: "Example: Linked-list pointer labels disappear when list size is 12."
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Add exact steps.
+      placeholder: |
+        1. Go to ...
+        2. Click ...
+        3. Observe ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      placeholder: "The pointer label should remain visible."
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      placeholder: "The pointer label gets clipped or disappears."
+    validations:
+      required: true
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      description: Browser/OS/device details.
+      placeholder: "Windows 11, Chrome 122, desktop"
+  - type: textarea
+    id: logs
+    attributes:
+      label: Extra context
+      description: Screenshots, console errors, or videos.
+      render: shell
+

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,57 @@
+name: Feature request
+description: Suggest an improvement or a new visualizer feature.
+title: "[Feature]: "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for sharing an idea. Clear use-cases help us prioritize better.
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues and didn't find a duplicate.
+          required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem statement
+      description: What user problem does this solve?
+      placeholder: "It is hard to follow pointer movement in linked-list animations."
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Describe your preferred solution.
+      placeholder: "Add a moving focus ring that follows the active pointer."
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      placeholder: "Highlight only labels, but that is less visible."
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Linked List Visualizer
+        - Sorting Visualizer
+        - Algorithms Page
+        - Home/Navigation
+        - Docs/Contributor Experience
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: extra
+    attributes:
+      label: Extra context
+      description: Mockups, references, or examples.
+


### PR DESCRIPTION
resolves issue #44
## Summary
This PR improves project documentation/contributor workflow by adding GitHub issue templates.

## Changes
- Added `.github/ISSUE_TEMPLATE/bug_report.yml`
- Added `.github/ISSUE_TEMPLATE/feature_request.yml`
- Added `.github/ISSUE_TEMPLATE/config.yml`