### PR TITLE
feat: Add dynamic page titles per algorithm for better SEO (#62)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,13 +1,16 @@
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>dsa-visualizer</title>
-  </head>
-  <body>
-    <div id="root"></div>
-    <script type="module" src="/src/main.jsx"></script>
-  </body>
+
+<head>
+  <meta charset="UTF-8" />
+  <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>DSA Visualizer</title>
+</head>
+
+<body>
+  <div id="root"></div>
+  <script type="module" src="/src/main.jsx"></script>
+</body>
+
 </html>

--- a/src/hooks/useDocumentTitle.js
+++ b/src/hooks/useDocumentTitle.js
@@ -1,0 +1,21 @@
+import { useEffect } from 'react';
+
+const BASE_TITLE = 'DSA Visualizer';
+
+/**
+ * Sets the document title for the current page.
+ * Format: "Page Name — DSA Visualizer"
+ * Restores the base title on unmount.
+ *
+ * @param {string} title - The page-specific title segment.
+ */
+export function useDocumentTitle(title) {
+    useEffect(() => {
+        const previousTitle = document.title;
+        document.title = title ? `${title} — ${BASE_TITLE}` : BASE_TITLE;
+
+        return () => {
+            document.title = previousTitle;
+        };
+    }, [title]);
+}

--- a/src/pages/Algorithms.jsx
+++ b/src/pages/Algorithms.jsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from 'react';
+import { useDocumentTitle } from '../hooks/useDocumentTitle';
 import { Link } from 'react-router-dom';
 import { motion, useReducedMotion } from 'framer-motion';
 import {
@@ -86,7 +87,7 @@ const algorithmsCatalog = [
     icon: Search,
     gradient: 'from-emerald-400/25 via-teal-500/15 to-transparent',
     accent: 'text-emerald-100',
-},
+  },
   {
     id: 'radix-sort',
     title: 'Radix Sort',
@@ -183,6 +184,7 @@ const complexityRank = {
 };
 
 export default function Algorithms() {
+  useDocumentTitle('Algorithms');
 
   const [activeFilter, setActiveFilter] = useState('all');
   const [searchText, setSearchText] = useState('');

--- a/src/pages/Contact.jsx
+++ b/src/pages/Contact.jsx
@@ -1,9 +1,11 @@
 "use client";
 
 import { useState } from "react";
+import { useDocumentTitle } from "../hooks/useDocumentTitle";
 import toast, { Toaster } from "react-hot-toast";
 
 export default function Contact() {
+  useDocumentTitle("Contact");
   const [form, setForm] = useState({
     firstName: "",
     lastName: "",

--- a/src/pages/GraphVisualizerPage.jsx
+++ b/src/pages/GraphVisualizerPage.jsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useDocumentTitle } from '../hooks/useDocumentTitle';
 import { motion } from 'framer-motion';
 import {
     Activity,
@@ -111,6 +112,7 @@ function renderHighlightedCode(code) {
 
 
 export default function GraphVisualizerPage() {
+    useDocumentTitle('Depth First Search');
     const [graph, setGraph] = useState({ nodes: [], edges: [] });
     const [nodeCount, setNodeCount] = useState(8);
     const [speed, setSpeed] = useState(250);

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,4 +1,5 @@
 import { motion } from 'framer-motion';
+import { useDocumentTitle } from '../hooks/useDocumentTitle';
 import HeroCopy from '../components/home/HeroCopy';
 import LivePreviewCard from '../components/home/LivePreviewCard';
 import FeaturesGrid from '../components/home/FeaturesGrid';
@@ -16,6 +17,7 @@ const MotionSection = motion.section;
 const MotionDiv = motion.div;
 
 export default function Home() {
+  useDocumentTitle('Home');
   return (
     <div className="relative overflow-hidden">
       <MotionDiv className="pointer-events-none absolute -top-28 left-1/2 h-72 w-72 -translate-x-1/2 rounded-full bg-blue-600/25 blur-3xl" />

--- a/src/pages/LinkedListVisualizerPage.jsx
+++ b/src/pages/LinkedListVisualizerPage.jsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useDocumentTitle } from "../hooks/useDocumentTitle";
 import { motion } from "framer-motion";
 import {
   Activity,
@@ -266,6 +267,7 @@ export default function LinkedListVisualizerPage() {
   const MotionDiv = motion.div;
 
   const activeAlgorithm = linkedListAlgorithms[selectedAlgorithm];
+  useDocumentTitle(activeAlgorithm.title);
   const activeCodeSnippet =
     selectedLanguage === "C++"
       ? activeAlgorithm.cppSnippet
@@ -876,11 +878,10 @@ export default function LinkedListVisualizerPage() {
                 pointerSummary.map((pointer) => (
                   <span
                     key={pointer.key}
-                    className={`rounded-lg px-2.5 py-1 text-xs font-semibold uppercase tracking-wide ${
-                      focusPointer?.key === pointer.key
-                        ? "border border-amber-400/50 bg-amber-500/20 text-amber-100"
-                        : "border border-cyan-400/30 bg-cyan-500/10 text-cyan-100"
-                    }`}
+                    className={`rounded-lg px-2.5 py-1 text-xs font-semibold uppercase tracking-wide ${focusPointer?.key === pointer.key
+                      ? "border border-amber-400/50 bg-amber-500/20 text-amber-100"
+                      : "border border-cyan-400/30 bg-cyan-500/10 text-cyan-100"
+                      }`}
                   >
                     {pointer.label}: {pointer.value}
                   </span>

--- a/src/pages/SignIn.jsx
+++ b/src/pages/SignIn.jsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useDocumentTitle } from '../hooks/useDocumentTitle';
 import { motion } from 'framer-motion';
 import { Link } from 'react-router-dom';
 import { Mail, Lock, ArrowRight, Loader2 } from 'lucide-react';
@@ -23,6 +24,7 @@ const itemVariants = {
 };
 
 export default function SignIn() {
+    useDocumentTitle('Sign In');
     const [formData, setFormData] = useState({
         email: '',
         password: '',

--- a/src/pages/SignUp.jsx
+++ b/src/pages/SignUp.jsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useDocumentTitle } from '../hooks/useDocumentTitle';
 import { motion } from 'framer-motion';
 import { Link } from 'react-router-dom';
 import { User, Mail, Lock, ArrowRight, Loader2 } from 'lucide-react';
@@ -23,6 +24,7 @@ const itemVariants = {
 };
 
 export default function SignUp() {
+    useDocumentTitle('Sign Up');
     const [formData, setFormData] = useState({
         name: '',
         email: '',

--- a/src/pages/VisualizerPage.jsx
+++ b/src/pages/VisualizerPage.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
+import { useDocumentTitle } from "../hooks/useDocumentTitle";
 import { motion } from "framer-motion";
 import {
   Activity,
@@ -289,6 +290,7 @@ export default function VisualizerPage({
   pythonSnippet,
 }) {
   const { array, setArray, generateRandomArray } = useVisualizer();
+  useDocumentTitle(name);
   const [isSorting, setIsSorting] = useState(false);
   const [isPaused, setIsPaused] = useState(false);
   const [runStatus, setRunStatus] = useState("Idle");


### PR DESCRIPTION
Added dynamic `document.title` to all pages so each browser tab shows
the algorithm/page name instead of the generic "dsa-visualizer".
**Format:** `Page Name — DSA Visualizer`
Closes #62
<img width="637" height="330" alt="Screenshot 2026-02-19 144115" src="https://github.com/user-attachments/assets/b9721a1c-9ca7-4dd3-a8f9-0681a5b84559" />
<img width="517" height="361" alt="Screenshot 2026-02-19 144106" src="https://github.com/user-attachments/assets/d79eb616-0c1c-4d7d-92a1-752c2327c340" />
