### PR TITLE
feat: Add new Home page with interactive live preview, outcomes secti…

### DIFF
--- a/src/components/home/FeaturesGrid.jsx
+++ b/src/components/home/FeaturesGrid.jsx
@@ -8,7 +8,7 @@ export default function FeaturesGrid({ features }) {
         return (
           <TiltCard
             key={feature.title}
-            className="rounded-3xl border border-slate-700/70 bg-slate-800/40 p-7 shadow-lg shadow-slate-950/40 transition-colors duration-200 hover:border-blue-400/80"
+            className="rounded-3xl border border-white/10 bg-slate-800/40 p-7 shadow-lg shadow-slate-950/40 backdrop-blur-sm transition-colors duration-200 hover:border-blue-400/40"
           >
             <div className="mb-4 inline-flex rounded-2xl bg-blue-500/10 p-3 text-blue-400 [transform:translateZ(18px)]">
               <Icon size={22} />

--- a/src/components/home/HeroCopy.jsx
+++ b/src/components/home/HeroCopy.jsx
@@ -4,49 +4,60 @@ import { ArrowRight, Play } from 'lucide-react';
 export default function HeroCopy() {
   return (
     <>
-      <p className="mb-4 inline-flex items-center rounded-full border border-blue-400/30 bg-blue-500/10 px-4 py-1.5 text-xs font-bold tracking-[0.18em] text-blue-300 uppercase">
-        Interactive DSA Learning
-      </p>
+      <>
+        <p className="mb-6 inline-flex items-center gap-2 rounded-full border border-cyan-400/25 bg-cyan-500/10 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-cyan-200">
+          <span className="relative flex h-2 w-2">
+            <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-cyan-400 opacity-75"></span>
+            <span className="relative inline-flex rounded-full h-2 w-2 bg-cyan-500"></span>
+          </span>
+          Interactive DSA Learning
+        </p>
 
-      <h1 className="text-4xl font-black leading-tight tracking-tight text-white sm:text-5xl lg:text-6xl">
-        Understand Algorithms by
-        <span className="block text-blue-500">Watching Them Work</span>
-      </h1>
+        <h1 className="font-display text-4xl font-black leading-tight tracking-tight text-white sm:text-5xl lg:text-7xl">
+          Master Algorithms by
+          <span className="block text-transparent bg-clip-text bg-gradient-to-r from-sky-400 via-blue-500 to-violet-500">
+            Watching Them Work
+          </span>
+        </h1>
 
-      <p className="mt-6 max-w-xl text-base leading-relaxed text-slate-300 sm:text-lg">
-        DSA Lab turns algorithm logic into a step-by-step visual flow. Track each
-        operation in real time and connect implementation details with actual
-        behavior.
-      </p>
+        <p className="mt-6 max-w-xl text-base leading-relaxed text-slate-300 sm:text-lg">
+          DSA Lab turns complex logic into a step-by-step visual flow.
+          Track operations in real time, understand sorting mechanics, and
+          connect code with actual behavior.
+        </p>
 
-      <div className="mt-8 flex flex-wrap gap-4">
-        <Link
-          to="/algorithms"
-          className="inline-flex items-center gap-2 rounded-2xl bg-blue-600 px-7 py-3.5 text-sm font-bold tracking-wide text-white transition hover:bg-blue-500"
-        >
-          <Play size={18} fill="currentColor" />
-          Start Visualizing
-        </Link>
-        <Link
-          to="/contact"
-          className="inline-flex items-center gap-2 rounded-2xl border border-slate-600 bg-slate-900/70 px-7 py-3.5 text-sm font-bold tracking-wide text-slate-200 transition hover:border-blue-400 hover:text-white"
-        >
-          Contact Team
-          <ArrowRight size={18} />
-        </Link>
-      </div>
+        <div className="mt-10 flex flex-wrap gap-4">
+          <Link
+            to="/algorithms"
+            className="inline-flex items-center gap-2 rounded-full border border-blue-400/35 bg-blue-600/90 px-8 py-4 text-sm font-bold tracking-wide text-white transition-all hover:bg-blue-500 hover:scale-105 shadow-lg shadow-blue-900/40"
+          >
+            <Play size={18} fill="currentColor" />
+            Start Visualizing
+          </Link>
+          <Link
+            to="/contact"
+            className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-8 py-4 text-sm font-bold tracking-wide text-slate-200 transition-all hover:bg-white/10 hover:border-white/20"
+          >
+            Contact Team
+            <ArrowRight size={18} />
+          </Link>
+        </div>
 
-      <div className="mt-8 flex flex-wrap gap-3 text-xs font-semibold tracking-wide text-slate-300 uppercase">
-        <span className="rounded-full border border-slate-700 bg-slate-900/70 px-4 py-2">
-          Real-time Animation
-        </span>
-        <span className="rounded-full border border-slate-700 bg-slate-900/70 px-4 py-2">
-          Clean C++, Java Snippets
-        </span>
-        <span className="rounded-full border border-slate-700 bg-slate-900/70 px-4 py-2">
-          Open Source
-        </span>
-      </div>
+        <div className="mt-12 flex flex-wrap gap-x-6 gap-y-3 text-xs font-bold tracking-widest text-slate-400 uppercase">
+          <span className="flex items-center gap-2">
+            <div className="h-1.5 w-1.5 rounded-full bg-emerald-400 shadow-[0_0_8px_rgba(52,211,153,0.6)]" />
+            Real-time Animation
+          </span>
+          <span className="flex items-center gap-2">
+            <div className="h-1.5 w-1.5 rounded-full bg-blue-400 shadow-[0_0_8px_rgba(96,165,250,0.6)]" />
+            Clean C++ & Java
+          </span>
+          <span className="flex items-center gap-2">
+            <div className="h-1.5 w-1.5 rounded-full bg-violet-400 shadow-[0_0_8px_rgba(167,139,250,0.6)]" />
+            Open Source
+          </span>
+        </div>
+      </>
     </>
   );
 }

--- a/src/components/home/HowItWorksSection.jsx
+++ b/src/components/home/HowItWorksSection.jsx
@@ -2,18 +2,18 @@ import TiltCard from './TiltCard';
 
 export default function HowItWorksSection({ steps }) {
   return (
-    <div className="rounded-3xl border border-slate-700/70 bg-slate-900/70 p-8 md:p-10">
+    <div className="rounded-3xl border border-white/10 bg-slate-800/20 p-8 backdrop-blur-sm md:p-10">
       <p className="text-xs font-bold tracking-[0.2em] text-blue-300 uppercase">
         How It Works
       </p>
-      <h2 className="mt-3 text-3xl font-black text-white sm:text-4xl">
+      <h2 className="mt-3 font-display text-3xl font-black text-white sm:text-4xl">
         Learn DSA with a repeatable flow
       </h2>
       <div className="mt-8 grid gap-5 md:grid-cols-3">
         {steps.map((item) => (
           <TiltCard
             key={item.step}
-            className="rounded-2xl border border-slate-700 bg-slate-800/60 p-6 transition-colors duration-200 hover:border-blue-400/75"
+            className="rounded-2xl border border-white/10 bg-slate-800/40 p-6 transition-colors duration-200 hover:border-blue-400/50"
           >
             <p className="text-sm font-black text-blue-400 [transform:translateZ(14px)]">
               {item.step}

--- a/src/components/home/LivePreviewCard.jsx
+++ b/src/components/home/LivePreviewCard.jsx
@@ -92,10 +92,10 @@ export default function LivePreviewCard() {
   }, [isPreviewRunning]);
 
   return (
-    <div className="rounded-3xl border border-slate-700/70 bg-slate-900/80 p-5 shadow-2xl shadow-blue-950/30 backdrop-blur-sm">
-      <div className="mb-5 flex items-center justify-between border-b border-slate-700/60 pb-3">
+    <div className="rounded-3xl border border-white/10 bg-slate-800/40 p-5 shadow-2xl shadow-blue-950/30 backdrop-blur-sm">
+      <div className="mb-5 flex items-center justify-between border-b border-white/10 pb-3">
         <div>
-          <p className="text-xs font-bold tracking-[0.2em] text-slate-300 uppercase">
+          <p className="text-xs font-bold tracking-[0.2em] text-slate-400 uppercase">
             Live Preview
           </p>
           <p className="mt-1 text-xs text-slate-400">
@@ -106,7 +106,7 @@ export default function LivePreviewCard() {
           <button
             type="button"
             onClick={() => setIsPreviewRunning((prev) => !prev)}
-            className="inline-flex h-8 w-8 items-center justify-center rounded-lg border border-slate-600 bg-slate-800/90 text-slate-100 transition hover:border-blue-400 hover:text-white"
+            className="inline-flex h-8 w-8 items-center justify-center rounded-lg border border-white/10 bg-white/5 text-slate-100 transition hover:bg-white/10 hover:text-white"
             aria-label={isPreviewRunning ? 'Pause preview' : 'Play preview'}
           >
             {isPreviewRunning ? <Pause size={15} /> : <Play size={15} fill="currentColor" />}
@@ -114,7 +114,7 @@ export default function LivePreviewCard() {
           <button
             type="button"
             onClick={handleShufflePreview}
-            className="inline-flex h-8 w-8 items-center justify-center rounded-lg border border-slate-600 bg-slate-800/90 text-slate-100 transition hover:border-blue-400 hover:text-white"
+            className="inline-flex h-8 w-8 items-center justify-center rounded-lg border border-white/10 bg-white/5 text-slate-100 transition hover:bg-white/10 hover:text-white"
             aria-label="Shuffle preview bars"
           >
             <RotateCcw size={15} />
@@ -126,7 +126,7 @@ export default function LivePreviewCard() {
         ref={previewFrameRef}
         onPointerMove={handlePreviewPointerMove}
         onPointerLeave={() => setHoveredPreviewBar(null)}
-        className="flex h-64 items-end justify-between gap-2 rounded-2xl border border-slate-700/60 bg-slate-800/50 p-4"
+        className="flex h-64 items-end justify-between gap-2 rounded-2xl border border-white/10 bg-slate-900/50 p-4"
       >
         {previewBars.map((height, idx) => {
           const isComparing = idx === previewPair[0] || idx === previewPair[1];
@@ -141,13 +141,12 @@ export default function LivePreviewCard() {
                 filter: isHovered ? 'brightness(1.18)' : 'brightness(1)',
               }}
               transition={{ duration: 0.32, ease: 'easeOut' }}
-              className={`w-full rounded-t-md ${
-                isHovered
-                  ? 'bg-gradient-to-t from-cyan-500 to-blue-300'
+              className={`w-full rounded-t-md ${isHovered
+                  ? 'bg-gradient-to-t from-cyan-400 to-blue-300'
                   : isComparing
-                    ? 'bg-gradient-to-t from-amber-500 to-yellow-300'
-                    : 'bg-gradient-to-t from-blue-700 to-blue-400'
-              }`}
+                    ? 'bg-gradient-to-t from-amber-400 to-orange-300'
+                    : 'bg-gradient-to-t from-blue-600 to-indigo-400'
+                }`}
             />
           );
         })}

--- a/src/components/home/OutcomesSection.jsx
+++ b/src/components/home/OutcomesSection.jsx
@@ -4,11 +4,11 @@ import TiltCard from './TiltCard';
 
 export default function OutcomesSection({ outcomes }) {
   return (
-    <div className="mt-10 rounded-3xl border border-slate-700/70 bg-slate-900/70 p-8 md:p-10">
+    <div className="mt-10 rounded-3xl border border-white/10 bg-slate-800/20 p-8 backdrop-blur-sm md:p-10">
       <p className="text-xs font-bold tracking-[0.2em] text-blue-300 uppercase">
         Outcomes
       </p>
-      <h3 className="mt-3 text-3xl font-black text-white sm:text-4xl">
+      <h3 className="mt-3 font-display text-3xl font-black text-white sm:text-4xl">
         What you improve in every practice run
       </h3>
 
@@ -18,7 +18,7 @@ export default function OutcomesSection({ outcomes }) {
           return (
             <TiltCard
               key={item.title}
-              className="rounded-2xl border border-slate-700 bg-slate-800/60 p-6 transition-colors duration-200 hover:border-blue-400/75"
+              className="rounded-2xl border border-white/10 bg-slate-800/40 p-6 transition-colors duration-200 hover:border-blue-400/50"
             >
               <div className="mb-4 inline-flex rounded-xl bg-blue-500/10 p-2.5 text-blue-400 [transform:translateZ(18px)]">
                 <Icon size={20} />
@@ -37,13 +37,13 @@ export default function OutcomesSection({ outcomes }) {
         })}
       </div>
 
-      <div className="mt-8 flex flex-wrap items-center justify-between gap-4 rounded-2xl border border-slate-700/70 bg-slate-800/40 px-5 py-4">
+      <div className="mt-8 flex flex-wrap items-center justify-between gap-4 rounded-2xl border border-white/10 bg-slate-800/40 px-5 py-4">
         <p className="text-sm text-slate-200">
           Ready to practice with a full visual walkthrough?
         </p>
         <Link
           to="/algorithms"
-          className="inline-flex items-center gap-2 rounded-xl bg-blue-600 px-5 py-2.5 text-sm font-bold text-white transition hover:bg-blue-500"
+          className="inline-flex items-center gap-2 rounded-xl bg-blue-600 px-5 py-2.5 text-sm font-bold text-white transition hover:bg-blue-500 hover:shadow-lg hover:shadow-blue-900/40"
         >
           Explore Algorithms
           <ArrowRight size={16} />

--- a/src/components/home/TiltCard.jsx
+++ b/src/components/home/TiltCard.jsx
@@ -37,8 +37,8 @@ export default function TiltCard({ children, className = '' }) {
   const shadowBlurFar = useTransform(smoothHoverStrength, [0, 1], [0, 72]);
   const shadowBlueAlpha = useTransform(smoothHoverStrength, [0, 1], [0, 0.4]);
   const shadowCyanAlpha = useTransform(smoothHoverStrength, [0, 1], [0, 0.2]);
-  const dynamicShadow = useMotionTemplate`${shadowX}px ${shadowY}px ${shadowBlurNear}px rgba(37, 99, 235, ${shadowBlueAlpha}), ${shadowX}px ${shadowY}px ${shadowBlurFar}px rgba(34, 211, 238, ${shadowCyanAlpha})`;
-  const glareBackground = useMotionTemplate`radial-gradient(circle at ${glowX}% ${glowY}%, rgba(59, 130, 246, 0.42), rgba(34, 211, 238, 0.22) 28%, rgba(15, 23, 42, 0) 60%)`;
+  const dynamicShadow = useMotionTemplate`${shadowX}px ${shadowY}px ${shadowBlurNear}px rgba(56, 189, 248, ${shadowBlueAlpha}), ${shadowX}px ${shadowY}px ${shadowBlurFar}px rgba(139, 92, 246, ${shadowCyanAlpha})`;
+  const glareBackground = useMotionTemplate`radial-gradient(circle at ${glowX}% ${glowY}%, rgba(56, 189, 248, 0.3), rgba(139, 92, 246, 0.15) 30%, rgba(15, 23, 42, 0) 60%)`;
 
   const resetTilt = () => {
     rotateX.set(0);

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -20,9 +20,9 @@ export default function Home() {
   useDocumentTitle('Home');
   return (
     <div className="relative overflow-hidden">
-      <MotionDiv className="pointer-events-none absolute -top-28 left-1/2 h-72 w-72 -translate-x-1/2 rounded-full bg-blue-600/25 blur-3xl" />
-      <MotionDiv className="pointer-events-none absolute right-0 top-40 h-64 w-64 rounded-full bg-cyan-500/10 blur-3xl" />
-      <div className="pointer-events-none absolute -left-16 bottom-16 h-56 w-56 rounded-full bg-blue-500/10 blur-3xl" />
+      <MotionDiv className="pointer-events-none absolute -top-28 left-1/2 h-72 w-72 -translate-x-1/2 rounded-full bg-blue-600/20 blur-3xl opacity-50 mix-blend-screen" />
+      <MotionDiv className="pointer-events-none absolute right-0 top-40 h-80 w-80 rounded-full bg-cyan-500/10 blur-3xl opacity-40" />
+      <div className="pointer-events-none absolute -left-16 bottom-16 h-64 w-64 rounded-full bg-violet-500/10 blur-3xl opacity-40" />
 
       <MotionSection
         variants={containerVariants}


### PR DESCRIPTION
## Description
This PR redesigns the **Home Page** to achieve visual consistency with the **Algorithms Page**. It replaces the older slate-heavy theme with a modern **Glassmorphism** style, vibrant gradients, and improved typography.

please assign  it to me 
 close #71 


## From 
<img width="1870" height="886" alt="Screenshot 2026-02-19 224257" src="https://github.com/user-attachments/assets/5f965697-240b-47c6-9cc5-11884b048e68" />
<img width="1891" height="867" alt="Screenshot 2026-02-19 224342" src="https://github.com/user-attachments/assets/4ced5609-9f64-4f96-9dc1-332d90917f07" />


## To
<img width="1913" height="970" alt="Screenshot 2026-02-19 224916" src="https://github.com/user-attachments/assets/78b7fae4-b76c-4830-a7aa-4258edca8f6e" />
<img width="1793" height="922" alt="Screenshot 2026-02-19 224408" src="https://github.com/user-attachments/assets/0164d498-9ed6-4732-9100-4bd629abb8b6" />







