### PR TITLE
feat: implement graph (DFS) and linked list visualizers.

### DIFF
--- a/src/pages/GraphVisualizerPage.jsx
+++ b/src/pages/GraphVisualizerPage.jsx
@@ -76,6 +76,12 @@ function sleep(ms) {
 }
 
 
+function formatElapsed(seconds) {
+    const mins = Math.floor(seconds / 60).toString().padStart(2, "0");
+    const secs = (seconds % 60).toString().padStart(2, "0");
+    return `${mins}:${secs}`;
+}
+
 export default function GraphVisualizerPage() {
     useDocumentTitle('Depth First Search');
     const [graph, setGraph] = useState({ nodes: [], edges: [] });
@@ -86,6 +92,15 @@ export default function GraphVisualizerPage() {
     const [isPaused, setIsPaused] = useState(false);
     const [statusMessage, setStatusMessage] = useState("Generate a graph to start.");
     const [selectedLanguage, setSelectedLanguage] = useState("C++");
+    const [elapsedSeconds, setElapsedSeconds] = useState(0);
+
+    // Timer Effect
+    useEffect(() => {
+        if (!isRunning || isPaused) return undefined;
+        const timer = setInterval(() => setElapsedSeconds((s) => s + 1), 1000);
+        return () => clearInterval(timer);
+    }, [isRunning, isPaused]);
+
     const [copyState, setCopyState] = useState("idle");
 
     const activeCode = selectedLanguage === "C++" ? dfsCPP : (selectedLanguage === "Java" ? dfsJava : dfsPython);
@@ -106,6 +121,7 @@ export default function GraphVisualizerPage() {
         setIsRunning(false);
         setIsPaused(false);
         setRunStatus("Idle");
+        setElapsedSeconds(0);
         setStatusMessage("New graph generated.");
 
         if (containerRef.current) {
@@ -124,6 +140,8 @@ export default function GraphVisualizerPage() {
         pauseSignal.current = false;
         setIsRunning(false);
         setIsPaused(false);
+        setRunStatus("Idle");
+        setElapsedSeconds(0);
         setRunStatus("Idle");
         setGraph(prev => ({
             nodes: prev.nodes.map(n => ({ ...n, status: 'default' })),
@@ -153,6 +171,7 @@ export default function GraphVisualizerPage() {
         setRunStatus("Running");
         stopSignal.current = false;
         pauseSignal.current = false;
+        setElapsedSeconds(0);
 
         // Build Adj List
         const adj = Array.from({ length: graph.nodes.length }, () => []);
@@ -251,6 +270,9 @@ export default function GraphVisualizerPage() {
                     <div>
                         <div className="mb-4 flex flex-wrap items-center gap-2">
                             <span className="rounded-full border border-purple-400/25 bg-purple-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-widest text-purple-200">Graph</span>
+                            <span className="flex items-center gap-1 rounded-full border border-slate-700 bg-slate-800/50 px-3 py-1 text-xs font-semibold text-slate-300">
+                                <Clock3 size={12} className="text-slate-400" /> {formatElapsed(elapsedSeconds)}
+                            </span>
                             <span className={`rounded-full border px-3 py-1 text-xs font-semibold ${runStatusStyleMap[runStatus]}`}>{runStatus}</span>
                         </div>
                         <h1 className="font-display text-3xl font-black text-white sm:text-4xl lg:text-5xl">Depth First Search</h1>

--- a/src/pages/LinkedListVisualizerPage.jsx
+++ b/src/pages/LinkedListVisualizerPage.jsx
@@ -83,6 +83,12 @@ const nodeStatusClassMap = {
   middle: "border-violet-400/45 bg-violet-500/20 text-violet-100",
 };
 
+function formatElapsed(seconds) {
+  const mins = Math.floor(seconds / 60).toString().padStart(2, "0");
+  const secs = (seconds % 60).toString().padStart(2, "0");
+  return `${mins}:${secs}`;
+}
+
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -154,6 +160,14 @@ export default function LinkedListVisualizerPage() {
   );
   const [copyState, setCopyState] = useState("idle");
   const [selectedLanguage, setSelectedLanguage] = useState("C++");
+  const [elapsedSeconds, setElapsedSeconds] = useState(0);
+
+  // Timer Effect
+  useEffect(() => {
+    if (!isRunning || isPaused) return undefined;
+    const timer = setInterval(() => setElapsedSeconds((s) => s + 1), 1000);
+    return () => clearInterval(timer);
+  }, [isRunning, isPaused]);
 
   const stopSignal = useRef(false);
   const pauseSignal = useRef(false);
@@ -222,6 +236,7 @@ export default function LinkedListVisualizerPage() {
       setMarkers({ ...EMPTY_MARKERS, head: nextGraph.headIndex });
       setRunStatus("Idle");
       setStepCount(0);
+      setElapsedSeconds(0);
       setStatusMessage("New linked list generated.");
     },
     [hardStopRun],
@@ -233,6 +248,7 @@ export default function LinkedListVisualizerPage() {
     setMarkers({ ...EMPTY_MARKERS, head: headIndex });
     setRunStatus("Idle");
     setStepCount(0);
+    setElapsedSeconds(0);
     setStatusMessage("Pointers and highlights reset.");
   }, [hardStopRun, headIndex, resetNodeHighlights]);
 
@@ -351,6 +367,7 @@ export default function LinkedListVisualizerPage() {
     setIsPaused(false);
     setRunStatus("Running");
     setStepCount(0);
+    setElapsedSeconds(0);
 
     const completed =
       selectedAlgorithm === "reverse"
@@ -465,6 +482,9 @@ export default function LinkedListVisualizerPage() {
               <span className={`rounded-full border px-3 py-1 text-xs font-semibold ${runStatusStyleMap[runStatus]}`}>
                 {runStatus}
               </span>
+              <span className="flex items-center gap-1 rounded-full border border-slate-700 bg-slate-800/50 px-3 py-1 text-xs font-semibold text-slate-300">
+                <Clock3 size={12} className="text-slate-400" /> {formatElapsed(elapsedSeconds)}
+              </span>
             </div>
             <h1 className="font-display text-3xl font-black text-white sm:text-4xl lg:text-5xl">
               {activeAlgorithm.title}
@@ -480,7 +500,7 @@ export default function LinkedListVisualizerPage() {
               </div>
             </div>
             <div className="mt-5 grid grid-cols-2 gap-3 sm:grid-cols-4 text-center">
-              {[ { label: "Nodes", val: nodes.length, color: "text-white" }, { label: "Time", val: activeAlgorithm.complexity, color: "text-cyan-200" }, { label: "Space", val: activeAlgorithm.space, color: "text-blue-100" }, { label: "Steps", val: stepCount, color: "text-emerald-200" } ].map((stat) => (
+              {[{ label: "Nodes", val: nodes.length, color: "text-white" }, { label: "Time", val: activeAlgorithm.complexity, color: "text-cyan-200" }, { label: "Space", val: activeAlgorithm.space, color: "text-blue-100" }, { label: "Steps", val: stepCount, color: "text-emerald-200" }].map((stat) => (
                 <div key={stat.label} className="rounded-xl border border-white/10 bg-white/5 p-3">
                   <p className="text-[11px] uppercase tracking-wider text-slate-400">{stat.label}</p>
                   <p className={`mt-1 text-sm font-semibold ${stat.color}`}>{stat.val}</p>
@@ -594,9 +614,9 @@ export default function LinkedListVisualizerPage() {
             <span className="text-sm font-bold uppercase tracking-widest text-slate-200">{selectedLanguage} Source</span>
             <div className="ml-4 flex rounded-lg bg-white/5 p-1 border border-white/10">
               {["C++", "Python", "Java"].map((lang) => ( // Added Java to mapping
-                <button 
-                  key={lang} 
-                  onClick={() => setSelectedLanguage(lang)} 
+                <button
+                  key={lang}
+                  onClick={() => setSelectedLanguage(lang)}
                   className={`px-3 py-1 text-[10px] font-bold rounded-md transition-all ${selectedLanguage === lang ? "bg-blue-600 text-white" : "text-slate-400 hover:text-white"}`}
                 >
                   {lang}


### PR DESCRIPTION
have implemented an elapsed timer for the Graph and LinkedList visualizers to track the duration of algorithm execution, matching the style of the main Visualizer page.

Graph Visualizer:
Start DFS -> Timer starts counting.
Pause -> Timer pauses.
Reset -> Timer resets to 00:00.
New Graph -> Timer resets to 00:00.
LinkedList Visualizer:
Start Algorithm -> Timer starts counting.
Pause -> Timer pauses.
Reset -> Timer resets to 00:00.
Shuffle -> Timer resets to 00:00.
<img width="1507" height="747" alt="Screenshot 2026-02-20 013126" src="https://github.com/user-attachments/assets/b2b827d0-6ac5-4036-993f-97a87edb82ce" />
<img width="1566" height="776" alt="Screenshot 2026-02-20 013150" src="https://github.com/user-attachments/assets/be3fb9cb-20e3-4615-b29a-bb59d7812af4" />
 close #77 
