### PR TITLE
#205 Added Hash Table Open Addressing Visualizer — Linear, Quadratic & Double Hashing

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -176,7 +176,8 @@ function AppShell() {
           <Route path="/visualizer/singly-linked-list" element={<SinglyLinkedListPage />} />
           <Route path="/visualizer/doubly-linked-list" element={<DoublyLinkedListPage />} />
           <Route path="/visualizer/dll-to-bst" element={<DLLToBSTPage />} />
-
+          {/* Hash visualizers*/}
+          <Route path="/visualizer/hash-table" element={<HashTablePage />} />
           {/* Graph visualizers */}
           <Route path="/visualizer/dfs" element={<GraphVisualizerPage />} />
           <Route path="/visualizer/bfs" element={<BFSVisualizerPage />} />
@@ -215,7 +216,6 @@ function AppShell() {
           <Route path="/visualizer/segment-tree" element={<SegmentTreeVisualizerPage />} />
           <Route path="/visualizer/kadane" element={<KadanePage />} />
           <Route path="/visualizer/shunting-yard" element={<ShuntingYardPage />} />
-          <Route path="/visualizer/hash-table" element={<HashTablePage />} />
           <Route path="/compare" element={<ComparisonPage />} />
           <Route path="/cheatsheet" element={<CheatsheetPage />} />
           <Route path="*" element={<NotFoundPage />} />

--- a/src/algorithms/hashTable.js
+++ b/src/algorithms/hashTable.js
@@ -36,20 +36,33 @@ function nextProbe(strategy, key, size, attempt) {
   return h1; // chaining always uses h1
 }
 
+// ─── [NEW] Probe formula string for a given attempt ──────────────────────────
+function probeFormulaStr(strategy, h1, h2, attempt, size, resultIdx) {
+  if (strategy === "linear")
+    return `slot = (${h1} + ${attempt}) % ${size} = ${resultIdx}`;
+  if (strategy === "quadratic")
+    return `slot = (${h1} + ${attempt}²) % ${size} = ${resultIdx}`;
+  if (strategy === "double")
+    return `slot = (${h1} + ${attempt}×${h2}) % ${size} = ${resultIdx}`;
+  return "";
+}
+
 // ─── Step generator ───────────────────────────────────────────────────────────
 /**
  * Generates an array of frames describing each step of an operation.
  *
  * Frame shape:
  * {
- *   table        : Array<bucket>         – full snapshot of the table
- *   highlightIdx : number|null           – bucket index being examined
- *   probeIdx     : number|null           – current probe slot (OA only)
- *   action       : string                – short label
- *   description  : string                – longer explanation
- *   result       : "found"|"not-found"|"inserted"|"deleted"|"collision"|"probing"|null
- *   hashCalc     : { key, h1, h2? }     – hash computation shown in UI
- *   statsAfter   : { size, load }
+ *   table          : Array<bucket>         – full snapshot of the table
+ *   highlightIdx   : number|null           – bucket index being examined
+ *   probeIdx       : number|null           – current probe slot (OA only)
+ *   action         : string                – short label
+ *   description    : string                – longer explanation
+ *   result         : "found"|"not-found"|"inserted"|"deleted"|"collision"|"probing"|null
+ *   hashCalc       : { key, h1, h2? }     – hash computation shown in UI
+ *   statsAfter     : { size, occupied, tombstones, load }   ← [UPDATED] added tombstones
+ *   probeSequence  : number[]              – [NEW] probe indices visited so far (OA only)
+ *   probeFormula   : string                – [NEW] formula string for current probe (OA only)
  * }
  *
  * bucket shape (chaining)  : { entries: [{key,value,status}], status }
@@ -60,7 +73,10 @@ export function generateHashTableSteps(tableSize, strategy, operation, key, valu
   // Deep-clone so we never mutate the caller's state
   let table = deepClone(initialTable);
 
-  const snap = (highlightIdx, probeIdx, action, description, result, hashCalc) => {
+  // [NEW] track probe sequence across attempts for OA strategies
+  const probeSeq = [];
+
+  const snap = (highlightIdx, probeIdx, action, description, result, hashCalc, formula = "") => {
     frames.push({
       table: deepClone(table),
       highlightIdx,
@@ -70,6 +86,8 @@ export function generateHashTableSteps(tableSize, strategy, operation, key, valu
       result: result ?? null,
       hashCalc: hashCalc ?? null,
       statsAfter: computeStats(table, strategy),
+      probeSequence: [...probeSeq],   // [NEW]
+      probeFormula: formula,           // [NEW]
     });
   };
 
@@ -80,7 +98,7 @@ export function generateHashTableSteps(tableSize, strategy, operation, key, valu
   // ── Initial frame ───────────────────────────────────────────────────────────
   snap(null, null, "Start", `Beginning ${operation} for key "${key}"`, null, hashCalcBase);
 
-  // ── Hash computation frame ──────────────────────────────────────────────────
+  // ── Hash computation frame ────────────────────────────────��─────────────────
   snap(
     h1,
     null,
@@ -93,7 +111,7 @@ export function generateHashTableSteps(tableSize, strategy, operation, key, valu
   if (strategy === "chaining") {
     _chainingOp(frames, table, tableSize, operation, key, value, h1, snap, hashCalcBase);
   } else {
-    _openAddressingOp(frames, table, tableSize, strategy, operation, key, value, h1, snap, hashCalcBase);
+    _openAddressingOp(frames, table, tableSize, strategy, operation, key, value, h1, h2, snap, hashCalcBase, probeSeq);
   }
 
   return frames;
@@ -178,41 +196,44 @@ function _chainingOp(frames, table, tableSize, op, key, value, h1, snap, hc) {
 }
 
 // ─── Open addressing helpers ──────────────────────────────────────────────────
-function _openAddressingOp(frames, table, tableSize, strategy, op, key, value, h1, snap, hc) {
+// [UPDATED] accepts h2 + probeSeq so we can attach probeSequence & probeFormula to frames
+function _openAddressingOp(frames, table, tableSize, strategy, op, key, value, h1, h2, snap, hc, probeSeq) {
   const maxProbes = tableSize;
 
   if (op === "insert") {
     let inserted = false;
     for (let i = 0; i < maxProbes; i++) {
       const idx = nextProbe(strategy, key, tableSize, i);
+      probeSeq.push(idx); // [NEW]
+      const formula = probeFormulaStr(strategy, h1, h2, i, tableSize, idx); // [NEW]
       const slot = table[idx];
       if (i > 0) {
-        snap(h1, idx, "Probing", `Probe ${i}: checking slot ${idx} (${strategyLabel(strategy, i, hc)})`, "probing", hc);
+        snap(h1, idx, "Probing", `Probe ${i}: checking slot ${idx} (${strategyLabel(strategy, i, hc)})`, "probing", hc, formula);
       }
       if (!slot.entry || slot.entry.deleted) {
         if (i > 0) {
           slot.status = "collision";
-          snap(h1, idx, "Collision Resolved", `Slot ${idx} is free — inserting here after ${i} probe(s)`, "collision", hc);
+          snap(h1, idx, "Collision Resolved", `Slot ${idx} is free — inserting here after ${i} probe(s)`, "collision", hc, formula);
         }
         slot.entry = { key, value, status: "inserting" };
         slot.status = "active";
-        snap(h1, idx, "Inserting", `Inserting key "${key}" at slot ${idx}`, "inserted", hc);
+        snap(h1, idx, "Inserting", `Inserting key "${key}" at slot ${idx}`, "inserted", hc, formula);
         slot.entry.status = "inserted";
         slot.status = "default";
-        snap(h1, idx, "Done", `Key "${key}" inserted at slot ${idx}`, "inserted", hc);
+        snap(h1, idx, "Done", `Key "${key}" inserted at slot ${idx}`, "inserted", hc, formula);
         inserted = true;
         break;
       } else if (slot.entry.key === key) {
         slot.entry.status = "highlight";
-        snap(h1, idx, "Key Exists", `Key "${key}" already at slot ${idx} — updating value`, "collision", hc);
+        snap(h1, idx, "Key Exists", `Key "${key}" already at slot ${idx} — updating value`, "collision", hc, formula);
         slot.entry.value = value;
         slot.entry.status = "inserted";
-        snap(h1, idx, "Updated", `Value updated to "${value}"`, "inserted", hc);
+        snap(h1, idx, "Updated", `Value updated to "${value}"`, "inserted", hc, formula);
         inserted = true;
         break;
       } else {
         slot.status = "collision";
-        snap(h1, idx, "Collision!", `Slot ${idx} occupied by "${slot.entry.key}" — probing next`, "collision", hc);
+        snap(h1, idx, "Collision!", `Slot ${idx} occupied by "${slot.entry.key}" — probing next`, "collision", hc, formula);
         slot.status = "default";
       }
     }
@@ -223,21 +244,23 @@ function _openAddressingOp(frames, table, tableSize, strategy, op, key, value, h
     let found = false;
     for (let i = 0; i < maxProbes; i++) {
       const idx = nextProbe(strategy, key, tableSize, i);
+      probeSeq.push(idx); // [NEW]
+      const formula = probeFormulaStr(strategy, h1, h2, i, tableSize, idx); // [NEW]
       const slot = table[idx];
       slot.status = "active";
-      snap(h1, idx, "Probe", `Probe ${i}: checking slot ${idx}`, null, hc);
+      snap(h1, idx, "Probe", `Probe ${i}: checking slot ${idx}`, null, hc, formula);
       if (!slot.entry || (slot.entry === null && !slot.entry?.deleted)) {
         // Empty (not deleted) slot — key doesn't exist
         if (!slot.entry) {
           slot.status = "not-found";
-          snap(h1, idx, "Not Found", `Empty slot at ${idx} — key "${key}" not in table`, "not-found", hc);
+          snap(h1, idx, "Not Found", `Empty slot at ${idx} — key "${key}" not in table`, "not-found", hc, formula);
           slot.status = "default";
           break;
         }
       }
       if (slot.entry && !slot.entry.deleted && slot.entry.key === key) {
         slot.entry.status = "found";
-        snap(h1, idx, "Found!", `Key "${key}" found at slot ${idx} with value "${slot.entry.value}"`, "found", hc);
+        snap(h1, idx, "Found!", `Key "${key}" found at slot ${idx} with value "${slot.entry.value}"`, "found", hc, formula);
         found = true;
         break;
       } else {
@@ -251,21 +274,23 @@ function _openAddressingOp(frames, table, tableSize, strategy, op, key, value, h
     let deleted = false;
     for (let i = 0; i < maxProbes; i++) {
       const idx = nextProbe(strategy, key, tableSize, i);
+      probeSeq.push(idx); // [NEW]
+      const formula = probeFormulaStr(strategy, h1, h2, i, tableSize, idx); // [NEW]
       const slot = table[idx];
       slot.status = "active";
-      snap(h1, idx, "Probe", `Probe ${i}: checking slot ${idx}`, null, hc);
+      snap(h1, idx, "Probe", `Probe ${i}: checking slot ${idx}`, null, hc, formula);
       if (!slot.entry) {
         slot.status = "not-found";
-        snap(h1, idx, "Not Found", `Empty slot at ${idx} — key "${key}" doesn't exist`, "not-found", hc);
+        snap(h1, idx, "Not Found", `Empty slot at ${idx} — key "${key}" doesn't exist`, "not-found", hc, formula);
         slot.status = "default";
         break;
       }
       if (!slot.entry.deleted && slot.entry.key === key) {
         slot.entry.status = "deleting";
-        snap(h1, idx, "Deleting", `Found "${key}" at slot ${idx} — marking as deleted (tombstone)`, "deleted", hc);
+        snap(h1, idx, "Deleting", `Found "${key}" at slot ${idx} — marking as deleted (tombstone)`, "deleted", hc, formula);
         slot.entry.deleted = true;
         slot.entry.status = "deleted";
-        snap(h1, idx, "Done", `Slot ${idx} marked as tombstone ☠️`, "deleted", hc);
+        snap(h1, idx, "Done", `Slot ${idx} marked as tombstone ☠️`, "deleted", hc, formula);
         slot.status = "default";
         deleted = true;
         break;
@@ -289,13 +314,17 @@ function strategyLabel(strategy, attempt, hc) {
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 function computeStats(table, strategy) {
   let occupied = 0;
+  let tombstones = 0; // [NEW]
   const size = table.length;
   if (strategy === "chaining") {
     table.forEach((b) => { occupied += b.entries.length; });
   } else {
-    table.forEach((b) => { if (b.entry && !b.entry.deleted) occupied++; });
+    table.forEach((b) => {
+      if (b.entry && !b.entry.deleted) occupied++;
+      if (b.entry && b.entry.deleted) tombstones++; // [NEW]
+    });
   }
-  return { size, occupied, load: (occupied / size).toFixed(2) };
+  return { size, occupied, tombstones, load: (occupied / size).toFixed(2) }; // [UPDATED]
 }
 
 function deepClone(obj) {
@@ -363,7 +392,7 @@ int main() {
     cout << ht.search("apple") << endl; // -1
 }`;
 
-// ─── Java code snippet ────────────────────────────────────────────���───────────
+// ─── Java code snippet ────────────────────────────────────────────────────────
 export const hashTableJava = `import java.util.*;
 
 public class HashTable {

--- a/src/pages/HashTablePage.jsx
+++ b/src/pages/HashTablePage.jsx
@@ -43,6 +43,7 @@ import {
   shouldSkipHotkeyTarget,
   useStableHotkeys,
 } from "../hooks/useStableHotkeys";
+import { useDocumentTitle } from "../hooks/useDocumentTitle"; // [NEW]
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 const DEFAULT_SIZE = 7;
@@ -228,6 +229,107 @@ function TheoryPanel({ strategy }) {
   );
 }
 
+// ─── [NEW] Probe Sequence Diagram ─────────────────────────────────────────────
+function ProbeSequenceDiagram({ probeSequence, currentProbeIdx }) {
+  if (!probeSequence || probeSequence.length === 0) return null;
+  return (
+    <div className="rounded-xl bg-white/5 border border-white/10 p-3 space-y-2">
+      <p className="text-[10px] uppercase tracking-widest text-slate-400 flex items-center gap-1">
+        <Zap size={10} className="text-yellow-300" /> Probe Sequence
+      </p>
+      <div className="flex flex-wrap gap-1">
+        {probeSequence.map((slotIdx, i) => (
+          <motion.span
+            key={i}
+            initial={{ scale: 0.7, opacity: 0 }}
+            animate={{ scale: 1, opacity: 1 }}
+            className={`inline-flex items-center justify-center w-7 h-7 rounded-lg text-xs font-mono font-bold border transition-all ${
+              i === currentProbeIdx
+                ? "border-cyan-400/70 bg-cyan-500/30 text-cyan-100 ring-2 ring-cyan-400/40"
+                : i === 0
+                ? "border-violet-400/50 bg-violet-500/20 text-violet-200"
+                : "border-slate-600/50 bg-slate-700/40 text-slate-300"
+            }`}
+          >
+            {slotIdx}
+          </motion.span>
+        ))}
+      </div>
+      <p className="text-[10px] text-slate-500">
+        {probeSequence.length} probe{probeSequence.length !== 1 ? "s" : ""} so far
+      </p>
+    </div>
+  );
+}
+
+// ─── [NEW] Strategy Comparison Table (OA only) ────────────────────────────────
+function StrategyComparisonTable({ currentStrategy }) {
+  const [open, setOpen] = useState(false);
+  const rows = [
+    { name: "Formula", linear: "h(k) + i", quadratic: "h(k) + i²", double: "h1(k) + i×h2(k)" },
+    { name: "Clustering", linear: "Primary ✗", quadratic: "Secondary", double: "None ✓" },
+    { name: "Cache", linear: "⭐⭐⭐", quadratic: "⭐⭐", double: "⭐" },
+    { name: "Max Load", linear: "~70%", quadratic: "~50%", double: "~85%" },
+  ];
+  return (
+    <div className="rounded-2xl border border-white/10 bg-slate-800/40 overflow-hidden">
+      <button
+        onClick={() => setOpen((p) => !p)}
+        className="flex w-full items-center justify-between px-4 py-3 text-xs font-bold uppercase tracking-widest text-white hover:bg-white/5 transition-colors"
+      >
+        <span className="flex items-center gap-2">
+          <Zap size={13} className="text-cyan-300" />
+          OA Strategy Comparison
+        </span>
+        {open ? <ChevronUp size={13} /> : <ChevronDown size={13} />}
+      </button>
+      <AnimatePresence>
+        {open && (
+          <motion.div
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: "auto", opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            className="overflow-hidden"
+          >
+            <div className="border-t border-white/10 overflow-x-auto">
+              <table className="w-full text-[11px] text-slate-300">
+                <thead>
+                  <tr className="border-b border-white/10">
+                    <th className="px-3 py-2 text-left text-slate-400 font-semibold w-20"></th>
+                    {["linear", "quadratic", "double"].map((s) => (
+                      <th
+                        key={s}
+                        className={`px-3 py-2 text-center font-bold capitalize ${
+                          currentStrategy === s ? "text-cyan-200" : "text-slate-400"
+                        }`}
+                      >
+                        {s === "linear" ? "Linear" : s === "quadratic" ? "Quadratic" : "Double"}
+                        {currentStrategy === s && (
+                          <span className="ml-1 text-[9px] text-cyan-400">◀</span>
+                        )}
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {rows.map((row) => (
+                    <tr key={row.name} className="border-b border-white/5 hover:bg-white/5">
+                      <td className="px-3 py-2 text-slate-400 font-medium">{row.name}</td>
+                      <td className={`px-3 py-2 text-center font-mono ${currentStrategy === "linear" ? "text-slate-100" : "text-slate-500"}`}>{row.linear}</td>
+                      <td className={`px-3 py-2 text-center font-mono ${currentStrategy === "quadratic" ? "text-slate-100" : "text-slate-500"}`}>{row.quadratic}</td>
+                      <td className={`px-3 py-2 text-center font-mono ${currentStrategy === "double" ? "text-slate-100" : "text-slate-500"}`}>{row.double}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}
+
 // ─── Chaining table renderer ──────────────────────────────────────────────────
 function ChainingTable({ table, highlightIdx }) {
   return (
@@ -287,7 +389,7 @@ function ChainingTable({ table, highlightIdx }) {
 }
 
 // ─── Open addressing table renderer ──────────────────────────────────────────
-function OpenAddressTable({ table, highlightIdx, probeIdx }) {
+function OpenAddressTable({ table, highlightIdx, probeIdx, probeSequence }) {
   return (
     <div className="w-full space-y-1.5">
       {table.map((slot, i) => {
@@ -297,13 +399,15 @@ function OpenAddressTable({ table, highlightIdx, probeIdx }) {
             ? "active"
             : slot.status
           : slot.status;
+        // [NEW] mark previously visited slots with subtle dim ring
+        const wasVisited = probeSequence?.includes(i) && i !== probeIdx;
         return (
           <motion.div
             key={i}
             layout
             className={`flex items-center gap-2 rounded-xl border px-3 py-2 transition-all duration-200 ${
               bucketStatusClass[statusKey] || bucketStatusClass.default
-            }`}
+            } ${wasVisited ? "opacity-75" : ""}`}
           >
             <span className="w-7 shrink-0 text-center font-mono text-xs font-bold text-slate-400">
               {i}
@@ -331,11 +435,19 @@ function OpenAddressTable({ table, highlightIdx, probeIdx }) {
             ) : (
               <span className="text-[11px] text-slate-600 italic">empty</span>
             )}
-            {i === probeIdx && (
-              <span className="ml-auto shrink-0 rounded-full border border-violet-400/40 bg-violet-500/15 px-1.5 text-[10px] text-violet-300">
-                probe
-              </span>
-            )}
+            <div className="ml-auto flex items-center gap-1 shrink-0">
+              {/* [NEW] h1 badge on initial hash slot */}
+              {i === highlightIdx && i !== probeIdx && (
+                <span className="rounded-full border border-violet-400/40 bg-violet-500/15 px-1.5 text-[9px] text-violet-300">
+                  h1
+                </span>
+              )}
+              {i === probeIdx && (
+                <span className="rounded-full border border-violet-400/40 bg-violet-500/15 px-1.5 text-[10px] text-violet-300">
+                  probe
+                </span>
+              )}
+            </div>
           </motion.div>
         );
       })}
@@ -344,15 +456,24 @@ function OpenAddressTable({ table, highlightIdx, probeIdx }) {
 }
 
 // ─── Load factor bar ──────────────────────────────────────────────────────────
+// [UPDATED] strategy-specific thresholds + tombstone count
 function LoadFactorBar({ stats, strategy }) {
   if (!stats) return null;
   const loadPct = Math.round(parseFloat(stats.load) * 100);
+
+  // [NEW] strategy-specific warning thresholds
+  const warnThreshold =
+    strategy === "quadratic" ? 50 :
+    strategy === "double"    ? 85 :
+    75; // linear and chaining
+
   const color =
     loadPct < 50
       ? "bg-emerald-500"
-      : loadPct < 75
+      : loadPct < warnThreshold
         ? "bg-amber-500"
         : "bg-rose-500";
+
   return (
     <div className="rounded-xl bg-white/5 p-3 space-y-1.5">
       <div className="flex items-center justify-between text-[11px] text-slate-400">
@@ -361,7 +482,7 @@ function LoadFactorBar({ stats, strategy }) {
         </span>
         <span
           className={`font-bold font-mono ${
-            loadPct >= 75
+            loadPct >= warnThreshold
               ? "text-rose-300"
               : loadPct >= 50
                 ? "text-amber-300"
@@ -378,9 +499,15 @@ function LoadFactorBar({ stats, strategy }) {
           className={`h-full rounded-full ${color}`}
         />
       </div>
-      {!isChaining(strategy) && loadPct >= 75 && (
+      {!isChaining(strategy) && loadPct >= warnThreshold && (
         <p className="text-[10px] text-rose-300 flex items-center gap-1">
           <Info size={10} /> High load — consider resizing
+        </p>
+      )}
+      {/* [NEW] tombstone count */}
+      {!isChaining(strategy) && stats.tombstones > 0 && (
+        <p className="text-[10px] text-slate-400 flex items-center gap-1">
+          ☠ {stats.tombstones} tombstone{stats.tombstones !== 1 ? "s" : ""} — consider rebuilding
         </p>
       )}
     </div>
@@ -389,6 +516,7 @@ function LoadFactorBar({ stats, strategy }) {
 
 // ─── Main Page ─────────────────────────────────────────────────────────────────
 export default function HashTablePage() {
+  useDocumentTitle("Hash Table Visualizer"); // [NEW]
   const navigate = useNavigate();
 
   // Strategy & table size
@@ -429,7 +557,7 @@ export default function HashTablePage() {
     return hashTableCPP;
   }, [selectedLanguage]);
 
-  // ── Current step ─────────────────────────────────────────────────────────
+  // ── Current step ──────────────────────────────────────────────────────────
   const currentStep = useMemo(() => {
     if (currentStepIndex >= 0 && currentStepIndex < steps.length)
       return steps[currentStepIndex];
@@ -521,7 +649,7 @@ export default function HashTablePage() {
     setOpsLog([]);
   }, [strategy, tableSize, stopAnimation]);
 
-  // ── Step controls ─────────────────────��───────────────────────────────────
+  // ── Step controls ─────────────────────────────────────────────────────────
   const stepForward = useCallback(() => {
     if (currentStepIndex < steps.length - 1)
       setCurrentStepIndex((p) => p + 1);
@@ -598,12 +726,18 @@ export default function HashTablePage() {
   };
 
   // ── Hotkeys ───────────────────────────────────────────────────────────────
+  // [UPDATED] added ← → arrow key step navigation
   useStableHotkeys((e) => {
     if (shouldSkipHotkeyTarget(e.target)) return;
     const key = e.key?.toLowerCase();
+    if (e.repeat) { e.preventDefault(); return; }
+
+    // [NEW] arrow key stepping
+    if (e.code === "ArrowLeft") { e.preventDefault(); stepBackward(); return; }
+    if (e.code === "ArrowRight") { e.preventDefault(); stepForward(); return; }
+
     const isHotkey = e.code === "Space" || key === "r";
     if (!isHotkey) return;
-    if (e.repeat) { e.preventDefault(); return; }
     if (e.code === "Space") {
       e.preventDefault();
       if (runStatus === "Running" || runStatus === "Paused") {
@@ -1081,6 +1215,7 @@ export default function HashTablePage() {
                 table={displayTable}
                 highlightIdx={currentStep?.highlightIdx ?? null}
                 probeIdx={currentStep?.probeIdx ?? null}
+                probeSequence={currentStep?.probeSequence ?? []}  // [NEW]
               />
             )}
           </div>
@@ -1129,9 +1264,25 @@ export default function HashTablePage() {
                     )}
                   </p>
                 )}
+                {/* [NEW] probe formula display */}
+                {!isChaining(strategy) && currentStep.probeFormula && (
+                  <p className="mt-1 text-xs font-mono text-amber-300">
+                    {currentStep.probeFormula}
+                  </p>
+                )}
               </motion.div>
             )}
           </AnimatePresence>
+
+          {/* [NEW] Probe Sequence Diagram — OA only */}
+          {!isChaining(strategy) && currentStep?.probeSequence?.length > 0 && (
+            <div className="mt-3">
+              <ProbeSequenceDiagram
+                probeSequence={currentStep.probeSequence}
+                currentProbeIdx={currentStep.probeSequence.length - 1}
+              />
+            </div>
+          )}
 
           {/* Legend */}
           <div className="mt-4 rounded-xl bg-slate-800/80 p-3 border border-slate-700/50">
@@ -1206,6 +1357,13 @@ export default function HashTablePage() {
           <div className="mt-4">
             <TheoryPanel strategy={strategy} />
           </div>
+
+          {/* [NEW] OA Strategy Comparison — shown only for open addressing */}
+          {!isChaining(strategy) && (
+            <div className="mt-3">
+              <StrategyComparisonTable currentStrategy={strategy} />
+            </div>
+          )}
 
           {/* Hotkeys */}
           <div className="mt-4">


### PR DESCRIPTION
#205 
 New Features Added

### 1. 🔢 Probe Sequence Diagram
Live badge trail showing every slot index visited during the current operation. The currently active probe is highlighted in cyan, the initial hash slot in violet, and all previously visited slots in muted grey.
<img width="956" height="601" alt="Screenshot 2026-03-07 192700" src="https://github.com/user-attachments/assets/1dc41107-5193-4b04-9a95-ad026900e027" />
### 2. 🧮 Live Probe Formula Display
Each animation step now shows the exact formula used to compute the slot index for that probe attempt, displayed below the step description card.

- **Linear:** `slot = (3 + 1) % 7 = 4`
- **Quadratic:** `slot = (3 + 2²) % 7 = 0`
- **Double:** `slot = (3 + 1×5) % 7 = 1`
### 3. 📊 OA Strategy Comparison Table (accordion)
A collapsible comparison table (shown only for open addressing strategies) comparing Linear, Quadratic, and Double Hashing across formula, clustering behavior, cache performance, and recommended max load. The currently active strategy is highlighted.
<img width="878" height="413" alt="Screenshot 2026-03-07 192857" src="https://github.com/user-attachments/assets/0ba9b0a9-9c19-4726-b695-48e5ac725b44" />
